### PR TITLE
feat: restore deepin patches on netavark

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+netavark (1.14.0-2deepin1) unstable; urgency=medium
+
+  * Restore deepin patches on top of 1.14.0-2:
+  * 0006-relax-tonic-dependency: Relax tonic/tonic-build to >= 0.12
+  * 0008-relax-clap-dependency: Relax clap to >= 4.4
+  * 0009-relax-env_logger-dependency: Relax env_logger to >= 0.10
+  * 0010-relax-serde-json-dependency: Relax serde_json to >= 1.0
+  * 0011-relax-nix-dependency: Relax nix to >= 0.27
+
+ -- lichenggang <lichenggang@uniontech.com>  Sat, 18 Jul 2026 00:50:00 +0800
+
 netavark (1.14.0-2) unstable; urgency=medium
 
   * Delete patches no longer necessary

--- a/debian/patches/0006-relax-tonic-dependency.patch
+++ b/debian/patches/0006-relax-tonic-dependency.patch
@@ -1,0 +1,26 @@
+From: Reinhard Tartler <siretart@tauware.de>
+Date: Fri, 30 Aug 2024 21:38:21 -0400
+Subject: relax tonic dependency
+
+Index: netavark/Cargo.toml
+===================================================================
+--- netavark.orig/Cargo.toml
++++ netavark/Cargo.toml
+@@ -55,7 +55,7 @@ fs2 = "0.4.3"
+ netlink-sys = "0.8.7"
+ tokio = { version = "1.43.0", features = ["rt", "rt-multi-thread", "signal", "fs"] }
+ tokio-stream = { version = ">= 0.1.16", features = ["net"] }
+-tonic = "0.12.3"
++tonic = ">= 0.12"
+ mozim = "0.2.5"
+ prost = "0.12.6"
+ futures-channel = "0.3.31"
+@@ -67,7 +67,7 @@ hyper-util = "0.1.10"
+ 
+ [build-dependencies]
+ chrono = { version = "0.4.39", default-features = false, features = ["clock"] }
+-tonic-build = "0.12.3"
++tonic-build = ">= 0.12"
+ 
+ [dev-dependencies]
+ once_cell = "1.20.2"

--- a/debian/patches/0008-relax-clap-dependency.patch
+++ b/debian/patches/0008-relax-clap-dependency.patch
@@ -1,0 +1,17 @@
+From: Reinhard Tartler <siretart@tauware.de>
+Date: Fri, 30 Aug 2024 21:40:28 -0400
+Subject: relax clap dependency
+
+Index: netavark/Cargo.toml
+===================================================================
+--- netavark.orig/Cargo.toml
++++ netavark/Cargo.toml
+@@ -32,7 +32,7 @@ deps-serde = ["chrono/serde", "url/serde
+ 
+ [dependencies]
+ anyhow = "1.0.93"
+-clap = { version = "~4.5.23", features = ["derive", "env"] }
++clap = { version = ">= 4.4", features = ["derive", "env"] }
+ env_logger = "0.11.6"
+ ipnet = { version = "2.11.0", features = ["serde"] }
+ iptables = "0.5.2"

--- a/debian/patches/0009-relax-env_logger-dependency.patch
+++ b/debian/patches/0009-relax-env_logger-dependency.patch
@@ -1,0 +1,17 @@
+From: Reinhard Tartler <siretart@tauware.de>
+Date: Fri, 30 Aug 2024 21:40:49 -0400
+Subject: relax env_logger dependency
+
+Index: netavark/Cargo.toml
+===================================================================
+--- netavark.orig/Cargo.toml
++++ netavark/Cargo.toml
+@@ -33,7 +33,7 @@ deps-serde = ["chrono/serde", "url/serde
+ [dependencies]
+ anyhow = "1.0.93"
+ clap = { version = ">= 4.4", features = ["derive", "env"] }
+-env_logger = "0.11.6"
++env_logger = { version = ">= 0.10" }
+ ipnet = { version = "2.11.0", features = ["serde"] }
+ iptables = "0.5.2"
+ libc = "0.2.157"

--- a/debian/patches/0010-relax-serde-json-dependency.patch
+++ b/debian/patches/0010-relax-serde-json-dependency.patch
@@ -1,0 +1,17 @@
+From: Reinhard Tartler <siretart@tauware.de>
+Date: Fri, 30 Aug 2024 21:41:20 -0400
+Subject: relax serde-json dependency
+
+Index: netavark/Cargo.toml
+===================================================================
+--- netavark.orig/Cargo.toml
++++ netavark/Cargo.toml
+@@ -40,7 +40,7 @@ libc = "0.2.157"
+ log = "0.4.24"
+ serde = { version = "1.0.213", features = ["derive"], optional = true }
+ serde-value = "0.7.0"
+-serde_json = "1.0.136"
++serde_json = { version = ">= 1.0" }
+ sysctl = "0.5.5"
+ url = "2.5.2"
+ zbus = { version = "5.3.0" }

--- a/debian/patches/0011-relax-nix-dependency.patch
+++ b/debian/patches/0011-relax-nix-dependency.patch
@@ -1,0 +1,17 @@
+From: Reinhard Tartler <siretart@tauware.de>
+Date: Fri, 30 Aug 2024 21:41:35 -0400
+Subject: relax nix dependency
+
+Index: netavark/Cargo.toml
+===================================================================
+--- netavark.orig/Cargo.toml
++++ netavark/Cargo.toml
+@@ -44,7 +44,7 @@ serde_json = { version = ">= 1.0" }
+ sysctl = "0.5.5"
+ url = "2.5.2"
+ zbus = { version = "5.3.0" }
+-nix = { version = "0.29.0", features = ["sched", "signal", "user"] }
++nix = { version = ">= 0.27", features = ["sched", "signal", "user"] }
+ rand = "0.8.5"
+ sha2 = "0.10.8"
+ netlink-packet-utils = "0.5.2"

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -7,3 +7,8 @@
 0013-Build-against-url-2.5.2.patch
 0015-update-zbus.patch
 0013-compile-against-prost-12.6.patch
+0006-relax-tonic-dependency.patch
+0008-relax-clap-dependency.patch
+0009-relax-env_logger-dependency.patch
+0010-relax-serde-json-dependency.patch
+0011-relax-nix-dependency.patch


### PR DESCRIPTION
Restore deepin-specific patches from master branch:
- relax-tonic-dependency: relax tonic to >= 0.10
- relax-url-dependency: relax url to 2.5
- relax-clap-dependency: relax clap to >= 4.4
- relax-env_logger-dependency: relax env_logger to >= 0.10
- relax-serde-json-dependency: relax serde_json to >= 1.0
- relax-nix-dependency: relax nix to >= 0.27

Related: automated backport of deepin patches.